### PR TITLE
fix(test-syntax): disabled the restricted-syntax rule for tests

### DIFF
--- a/rules/tests/base.js
+++ b/rules/tests/base.js
@@ -5,6 +5,7 @@ module.exports = {
 
   rules: {
     'no-undefined': 'off',
-    'newline-per-chained-call': ['error', {ignoreChainWithDepth: 4}]
+    'newline-per-chained-call': ['error', {ignoreChainWithDepth: 4}],
+    'no-restricted-syntax': 'off'
   }
 };


### PR DESCRIPTION
this rule makes sense for production code, but having it enabled for tests makes it difficult to
ensure that the tests manipulate things differently from the production implementation, potentially
hiding implementation bugs