### PR TITLE
fix(es-6): remove depricated experimentalObjectRestSpread

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -9,9 +9,9 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
     ecmaFeatures: {
-      experimentalObjectRestSpread: true,
       classes: true
-    }
+    },
+    ecmaVersion: 2018
   },
 
   plugins: ['filenames', 'eslint-comments'],


### PR DESCRIPTION
```
[lint:js     ] (node:5513) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "@gaincompliance/gain/rules/es6")
```

* https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread